### PR TITLE
Add fields in Domains::StatusChange 

### DIFF
--- a/lib/seatsio/domain.rb
+++ b/lib/seatsio/domain.rb
@@ -414,7 +414,7 @@ module Seatsio::Domain
   end
 
   class StatusChange
-    attr_reader :extra_data, :object_label, :date, :id, :status, :event_id, :origin, :order_id, :quantity
+    attr_reader :extra_data, :object_label, :date, :id, :status, :event_id, :origin, :order_id, :quantity, :hold_token
 
     def initialize(data)
       @id = data['id']
@@ -426,6 +426,7 @@ module Seatsio::Domain
       @origin = StatusChangeOrigin.new(data['origin'])
       @order_id = data['orderId']
       @quantity = data['quantity']
+      @hold_token = data['holdToken']
     end
   end
 

--- a/lib/seatsio/domain.rb
+++ b/lib/seatsio/domain.rb
@@ -414,7 +414,7 @@ module Seatsio::Domain
   end
 
   class StatusChange
-    attr_reader :extra_data, :object_label, :date, :id, :status, :event_id, :origin
+    attr_reader :extra_data, :object_label, :date, :id, :status, :event_id, :origin, :order_id, :quantity
 
     def initialize(data)
       @id = data['id']
@@ -424,6 +424,8 @@ module Seatsio::Domain
       @event_id = data['eventId']
       @extra_data = data['extraData']
       @origin = StatusChangeOrigin.new(data['origin'])
+      @order_id = data['orderId']
+      @quantity = data['quantity']
     end
   end
 

--- a/test/events/list_status_changes_test.rb
+++ b/test/events/list_status_changes_test.rb
@@ -31,6 +31,8 @@ class ListStatusChangesTest < SeatsioTestClient
     assert_equal(event.id, status_change.event_id)
     assert_equal({'foo' => 'bar'}, status_change.extra_data)
     assert_equal('API_CALL', status_change.origin.type)
+    assert_equal('order1', status_change.order_id)
+    assert_equal(1, status_change.quantity)
     assert_not_nil(status_change.origin.ip)
   end
 

--- a/test/events/list_status_changes_test.rb
+++ b/test/events/list_status_changes_test.rb
@@ -17,8 +17,9 @@ class ListStatusChangesTest < SeatsioTestClient
     now = Time.now
     chart_key = create_test_chart
     event = @seatsio.events.create chart_key: chart_key
+    hold_token = @seatsio.hold_tokens.create
     object_properties = {:objectId => 'A-1', :extraData => {'foo': 'bar'}}
-    @seatsio.events.change_object_status(event.key, object_properties, 'status1', nil, 'order1')
+    @seatsio.events.change_object_status(event.key, object_properties, 'status1', hold_token.hold_token, 'order1')
 
     status_changes =  @seatsio.events.list_status_changes(event.key).to_a
     status_change = status_changes[0]
@@ -33,6 +34,7 @@ class ListStatusChangesTest < SeatsioTestClient
     assert_equal('API_CALL', status_change.origin.type)
     assert_equal('order1', status_change.order_id)
     assert_equal(1, status_change.quantity)
+    assert_equal(hold_token.hold_token, status_change.hold_token)
     assert_not_nil(status_change.origin.ip)
   end
 


### PR DESCRIPTION
Adds `orderId`, `quantity` and `holdToken` to response from `events.list_status_changes`.