### PR TITLE
add channels support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,11 @@ Rake::TestTask.new(:test) do |t|
   t.warning = false
 end
 
+Rake::TestTask.new(:singletest) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/update_channels_test.rb", "test/**/assign_objects_to_channels_test.rb"]
+  t.warning = false
+end
+
 task :default => :test

--- a/lib/seatsio/domain.rb
+++ b/lib/seatsio/domain.rb
@@ -109,7 +109,7 @@ module Seatsio::Domain
       @updated_on = parse_date(data['updatedOn'])
       @channels = data['channels'].map {
           |d| Channel.new(d['key'], d['name'], d['color'], d['index'], d['objects'])
-      }
+      } if data['channels']
     end
 
     def self.create_list(list = [])

--- a/lib/seatsio/domain.rb
+++ b/lib/seatsio/domain.rb
@@ -71,10 +71,31 @@ module Seatsio::Domain
     end
   end
 
+  class Channel
+    attr_reader :key, :name, :color, :index, :objects
+
+    def initialize(key, name, color, index, objects)
+      @key = key
+      @name = name
+      @color = color
+      @index = index
+      @objects = objects
+    end
+
+    def == (other)
+      self.key == other.key &&
+      self.name == other.name &&
+      self.color == other.color &&
+      self.index == other.index &&
+      self.objects == other.objects
+    end
+
+  end
+
   class Event
 
     attr_accessor :id, :key, :chart_key, :book_whole_tables, :supports_best_available,
-                  :table_booking_modes, :for_sale_config, :created_on, :updated_on
+                  :table_booking_modes, :for_sale_config, :created_on, :updated_on, :channels
 
     def initialize(data)
       @id = data['id']
@@ -86,6 +107,9 @@ module Seatsio::Domain
       @for_sale_config = ForSaleConfig.new(data['forSaleConfig']) if data['forSaleConfig']
       @created_on = parse_date(data['createdOn'])
       @updated_on = parse_date(data['updatedOn'])
+      @channels = data['channels'].map {
+          |d| Channel.new(d['key'], d['name'], d['color'], d['index'], d['objects'])
+      }
     end
 
     def self.create_list(list = [])
@@ -206,7 +230,7 @@ module Seatsio::Domain
   class ChartReportItem
 
     attr_reader :label, :labels, :category_key, :category_label, :section, :entrance, :capacity, :object_type,
-    :left_neighbour, :right_neighbour
+                :left_neighbour, :right_neighbour
 
     def initialize(data)
       @label = data['label']

--- a/lib/seatsio/events.rb
+++ b/lib/seatsio/events.rb
@@ -136,6 +136,14 @@ module Seatsio
       @http_client.post("events/#{key}/actions/mark-as-for-sale", request)
     end
 
+    def update_channels(key:, channels:)
+      @http_client.post("events/#{key}/channels/update", channels: channels)
+    end
+
+    def assign_objects_to_channels(key:, channelConfig:)
+      @http_client.post("events/#{key}/channels/assign-objects", channelConfig: channelConfig)
+    end
+
     private
 
     def build_parameters_for_mark_as_sale(objects: nil, categories: nil)

--- a/test/events/assign_objects_to_channels_test.rb
+++ b/test/events/assign_objects_to_channels_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'util'
+
+class AssignObjectsToChannelsTest < SeatsioTestClient
+
+  def test_assign_objects_to_channels
+    chart_key = create_test_chart
+    event = @seatsio.events.create chart_key: chart_key
+    @seatsio.events.update_channels key: event.key, channels: {
+        "channelKey1" => {"name" => "channel 1", "color" => "#FF0000", "index" => 1},
+        "channelKey2" => {"name" => "channel 2", "color" => "#0000FF", "index" => 2}
+    }
+
+    @seatsio.events.assign_objects_to_channels key: event.key, channelConfig: {
+        "channelKey1" => ["A-1", "A-2"],
+        "channelKey2" => ["A-3"]
+    }
+
+    retrieved_event = @seatsio.events.retrieve key: event.key
+    expected_channels = [
+        Seatsio::Domain::Channel.new("channelKey1", "channel 1", "#FF0000", 1, ["A-1", "A-2"]),
+        Seatsio::Domain::Channel.new("channelKey2", "channel 2", "#0000FF", 2, ["A-3"])
+    ]
+    assert_equal(expected_channels, retrieved_event.channels)
+
+  end
+
+end

--- a/test/events/update_channels_test.rb
+++ b/test/events/update_channels_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'util'
+
+class UpdateEventTest < SeatsioTestClient
+
+  def test_update_channels
+    chart = @seatsio.charts.create
+    event = @seatsio.events.create chart_key: chart.key
+
+    @seatsio.events.update_channels key: event.key, channels: {
+        "channelKey1" => {"name" => "channel 1", "color" => "#FF0000", "index" => 1},
+        "channelKey2" => {"name" => "channel 2", "color" => "#0000FF", "index" => 2}
+    }
+
+    retrieved_event = @seatsio.events.retrieve key: event.key
+    expected_channels = [
+        Seatsio::Domain::Channel.new("channelKey1", "channel 1", "#FF0000", 1, []),
+        Seatsio::Domain::Channel.new("channelKey2", "channel 2", "#0000FF", 2, [])
+    ]
+    assert_equal(expected_channels, retrieved_event.channels)
+  end
+
+end


### PR DESCRIPTION
2 new methods: one to update the channels list for an event, the other to assign channels to objects.