### PR TITLE
removed leading slashes from endpoints, to prevent double slashes

### DIFF
--- a/lib/seatsio/events.rb
+++ b/lib/seatsio/events.rb
@@ -32,7 +32,7 @@ module Seatsio
 
     def update(key:, chart_key: nil, event_key: nil, name: nil, date: nil, table_booking_config: nil, object_categories: nil, categories: nil, is_in_the_past: nil)
       payload = build_event_request(chart_key, event_key, name, date, table_booking_config, object_categories, categories, channels: nil, is_in_the_past: is_in_the_past)
-      @http_client.post("/events/#{key}", payload)
+      @http_client.post("events/#{key}", payload)
     end
 
     def override_season_object_status(key:, objects:)
@@ -117,7 +117,7 @@ module Seatsio
     end
 
     def delete(key:)
-      @http_client.delete("/events/#{key}")
+      @http_client.delete("events/#{key}")
     end
 
     def retrieve(key:)
@@ -133,12 +133,12 @@ module Seatsio
       if object_id != nil
         status_changes_for_object key: key, object_id: object_id
       else
-        Pagination::Cursor.new(StatusChange, "/events/#{key}/status-changes", @http_client)
+        Pagination::Cursor.new(StatusChange, "events/#{key}/status-changes", @http_client)
       end
     end
 
     def status_changes_for_object(key:, object_id:)
-      Pagination::Cursor.new(StatusChange, "/events/#{key}/objects/#{object_id}/status-changes", @http_client)
+      Pagination::Cursor.new(StatusChange, "events/#{key}/objects/#{object_id}/status-changes", @http_client)
     end
 
     def mark_as_not_for_sale(key:, objects: nil, area_places: nil, categories: nil)

--- a/lib/seatsio/hold_tokens.rb
+++ b/lib/seatsio/hold_tokens.rb
@@ -25,13 +25,13 @@ module Seatsio
     end
 
     def retrieve(hold_token)
-      response = @http_client.get("/hold-tokens/#{hold_token}")
+      response = @http_client.get("hold-tokens/#{hold_token}")
       HoldToken.new(response)
     end
 
     def expire_in_minutes(hold_token, expires_in_minutes = nil)
       body = {"expiresInMinutes": expires_in_minutes}
-      response = @http_client.post("/hold-tokens/#{hold_token}", body)
+      response = @http_client.post("hold-tokens/#{hold_token}", body)
       HoldToken.new(response)
     end
   end

--- a/lib/seatsio/seasons.rb
+++ b/lib/seatsio/seasons.rb
@@ -24,7 +24,7 @@ module Seatsio
       request = {}
       request['key'] = partial_season_key if partial_season_key
       request['eventKeys'] = event_keys if event_keys
-      response = @http_client.post("/seasons/#{top_level_season_key}/partial-seasons", request)
+      response = @http_client.post("seasons/#{top_level_season_key}/partial-seasons", request)
       Season.new(response)
     end
 
@@ -36,19 +36,19 @@ module Seatsio
       request = {}
       request['eventKeys'] = event_keys if event_keys
       request['numberOfEvents'] = number_of_events if number_of_events
-      response = @http_client.post("/seasons/#{key}/actions/create-events", request)
+      response = @http_client.post("seasons/#{key}/actions/create-events", request)
       Events.new(response).events
     end
 
     def add_events_to_partial_season(top_level_season_key:, partial_season_key:, event_keys:)
       request = {}
       request['eventKeys'] = event_keys
-      response = @http_client.post("/seasons/#{top_level_season_key}/partial-seasons/#{partial_season_key}/actions/add-events", request)
+      response = @http_client.post("seasons/#{top_level_season_key}/partial-seasons/#{partial_season_key}/actions/add-events", request)
       Season.new(response)
     end
 
     def remove_event_from_partial_season(top_level_season_key:, partial_season_key:, event_key:)
-      response = @http_client.delete("/seasons/#{top_level_season_key}/partial-seasons/#{partial_season_key}/events/#{event_key}")
+      response = @http_client.delete("seasons/#{top_level_season_key}/partial-seasons/#{partial_season_key}/events/#{event_key}")
       Season.new(response)
     end
 

--- a/lib/seatsio/workspaces.rb
+++ b/lib/seatsio/workspaces.rb
@@ -63,7 +63,7 @@ module Seatsio
     end
 
     def retrieve(key:)
-      response = @http_client.get("/workspaces/#{key}")
+      response = @http_client.get("workspaces/#{key}")
       Workspace.new(response)
     end
 


### PR DESCRIPTION
`@http_client.post("/events/#{key}", payload)`

resulted in (eg) `POST https://api-eu.seatsio.net//events/eventKey`

This PR fixes that, to get rid of the double forward slash