### PR TITLE
Use different parallel test runner to avoid ugly stack traces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,6 @@ jobs:
     - uses: zcong1993/setup-timezone@master
       with:
         timezone: Europe/Brussels
-    - run: parallel_test
+    - run: bundle exec parallel_test
       env:
         DEMO_COMPANY_SECRET_KEY: ${{ secrets.DEMO_COMPANY_SECRET_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,6 @@ jobs:
     - uses: zcong1993/setup-timezone@master
       with:
         timezone: Europe/Brussels
-    - run: bundle exec rake
+    - run: parallel_test
       env:
         DEMO_COMPANY_SECRET_KEY: ${{ secrets.DEMO_COMPANY_SECRET_KEY }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,38 +7,35 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     bigdecimal (3.1.8)
     crack (1.0.0)
       bigdecimal
       rexml
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    domain_name (0.6.20240107)
     hashdiff (1.1.0)
     http-accept (1.7.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.6)
       domain_name (~> 0.5)
-    mime-types (3.3.1)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
-    minitest (5.23.1)
-    minitest-parallel_fork (2.0.0)
-      minitest (>= 5.15.0)
+    mime-types-data (3.2024.0702)
+    minitest (5.24.1)
     netrc (0.11.0)
-    public_suffix (5.0.5)
+    parallel (1.25.1)
+    parallel_tests (4.7.1)
+      parallel
+    public_suffix (6.0.0)
     rake (13.2.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.1)
+      strscan
     strscan (3.1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.7)
     webmock (3.23.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -50,10 +47,10 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.2)
   minitest (~> 5.0)
-  minitest-parallel_fork (~> 2.0)
+  parallel_tests (~> 4.7.1)
   rake (~> 13.0)
   seatsio!
   webmock (~> 3.4, >= 3.4.2)
 
 BUNDLED WITH
-   2.1.4
+   2.5.3

--- a/seatsio.gemspec
+++ b/seatsio.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'
-  spec.add_development_dependency 'minitest-parallel_fork', '~> 2.0'
+  spec.add_development_dependency 'parallel_tests', '~> 4.7.1'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'webmock/minitest'
 require "seatsio"
 require "minitest/autorun"
-require "minitest/parallel_fork"
 require 'custom_assertions'
 require 'seatsio_test_client'
 


### PR DESCRIPTION
This PR fixes stack traces that would be printed, even when the tests were successful:

```
Traceback (most recent call last):
	12: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-5.24.1/lib/minitest.rb:86:in `block in autorun'
	11: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-5.24.1/lib/minitest.rb:288:in `run'
	10: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:129:in `__run'
	 9: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:85:in `parallel_fork_setup_children'
	 8: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:85:in `map'
	 7: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:85:in `each'
	 6: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:85:in `times'
	 5: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:87:in `block in parallel_fork_setup_children'
	 4: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:87:in `fork'
	 3: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:95:in `block (2 levels) in parallel_fork_setup_children'
	 2: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:54:in `parallel_fork_data_to_marshal'
	 1: from /Users/mroloux/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/minitest-parallel_fork-2.0.0/lib/minitest/parallel_fork.rb:54:in `map'
```