### PR TITLE
Remove update chart key for event

### DIFF
--- a/lib/seatsio/events.rb
+++ b/lib/seatsio/events.rb
@@ -30,8 +30,8 @@ module Seatsio
       Events.new(response).events
     end
 
-    def update(key:, chart_key: nil, event_key: nil, name: nil, date: nil, table_booking_config: nil, object_categories: nil, categories: nil, is_in_the_past: nil)
-      payload = build_event_request(chart_key, event_key, name, date, table_booking_config, object_categories, categories, channels: nil, is_in_the_past: is_in_the_past)
+    def update(key:, event_key: nil, name: nil, date: nil, table_booking_config: nil, object_categories: nil, categories: nil, is_in_the_past: nil)
+      payload = build_event_request(nil, event_key, name, date, table_booking_config, object_categories, categories, channels: nil, is_in_the_past: is_in_the_past)
       @http_client.post("events/#{key}", payload)
     end
 

--- a/test/events/update_event_test.rb
+++ b/test/events/update_event_test.rb
@@ -2,18 +2,6 @@ require 'test_helper'
 require 'util'
 
 class UpdateEventTest < SeatsioTestClient
-  def test_update_chart_key
-    chart1 = @seatsio.charts.create
-    event = @seatsio.events.create chart_key: chart1.key
-    chart2 = @seatsio.charts.create
-
-    @seatsio.events.update key: event.key, chart_key: chart2.key
-
-    retrieved_event = @seatsio.events.retrieve key: event.key
-    assert_equal(event.key, retrieved_event.key)
-    assert_equal(chart2.key, retrieved_event.chart_key)
-  end
-
   def test_update_event_key
     chart = @seatsio.charts.create
     event = @seatsio.events.create chart_key: chart.key


### PR DESCRIPTION
Updating the chart key of an event is no longer documented but is still supported by the client libraries. This PR removes the parameter from `events#update`.