### PR TITLE
distinct exception type thrown when best available objects not found

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0702)
-    minitest (5.25.2)
+    minitest (5.25.4)
     netrc (0.11.0)
     parallel (1.26.3)
     parallel_tests (4.7.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    seatsio (51.2.0)
+    seatsio (51.3.0)
       rest-client (~> 2.0, >= 2.0.2)
 
 GEM

--- a/lib/seatsio/exception.rb
+++ b/lib/seatsio/exception.rb
@@ -6,6 +6,9 @@ module Seatsio
     class RateLimitExceededException < SeatsioException
     end
 
+    class BestAvailableObjectsNotFoundException < SeatsioException
+    end
+
     class NoMorePagesException < SeatsioException
     end
 

--- a/lib/seatsio/httpClient.rb
+++ b/lib/seatsio/httpClient.rb
@@ -94,12 +94,14 @@ module Seatsio
     private
 
     def handle_exception(response)
+      if response.code == 429
+        raise Exception::RateLimitExceededException.new(response)
+      end
+
       content_type = response.headers[:content_type]
       if content_type&.include?("application/json")
         parsed_exception = JSON.parse(response.body, symbolize_names: true)
-        if response.code == 429
-          raise Exception::RateLimitExceededException.new(response)
-        elsif best_available_objects_not_found?(parsed_exception[:errors])
+        if best_available_objects_not_found?(parsed_exception[:errors])
           raise Exception::BestAvailableObjectsNotFoundException.new(response)
         else
           raise Exception::SeatsioException.new(response)

--- a/lib/seatsio/version.rb
+++ b/lib/seatsio/version.rb
@@ -1,3 +1,3 @@
 module Seatsio
-  VERSION = "51.2.0"
+  VERSION = "51.3.0"
 end

--- a/test/custom_assertions.rb
+++ b/test/custom_assertions.rb
@@ -30,4 +30,9 @@ module Minitest::Assertions
   def assert_empty(actual)
     assert_equal([], actual)
   end
+
+  def assert_not_instance_of(expected_class, actual)
+    refute_instance_of(expected_class, actual)
+  end
+
 end

--- a/test/events/change_best_available_object_status_test.rb
+++ b/test/events/change_best_available_object_status_test.rb
@@ -213,4 +213,25 @@ class ChangeBestAvailableObjectStatusTest < SeatsioTestClient
     assert_equal(true, result.next_to_each_other)
     assert_equal(%w(A-6 A-7 A-8), result.objects)
   end
+
+  def test_specific_exception_type_when_best_available_result_not_found
+    chart_key = create_test_chart
+    event = @seatsio.events.create chart_key: chart_key
+
+    begin
+      @seatsio.events.change_best_available_object_status(event.key, 3000, 'myStatus')
+      raise "Should have failed"
+    rescue Seatsio::Exception::BestAvailableObjectsNotFoundException => e
+      assert_equal("BEST_AVAILABLE_OBJECTS_NOT_FOUND", JSON.parse(e.message)['errors'].first['code'])
+    end
+  end
+
+  def test_general_exception_type_when_eg_event_not_found
+    begin
+      @seatsio.events.change_best_available_object_status("unexisting_event", 3000, 'myStatus')
+      raise "Should have failed"
+    rescue Seatsio::Exception::SeatsioException => e
+      assert_not_instance_of(Seatsio::Exception::BestAvailableObjectsNotFoundException, e)
+    end
+  end
 end

--- a/test/exponential_backoff_test.rb
+++ b/test/exponential_backoff_test.rb
@@ -24,7 +24,7 @@ class ExponentialBackoffTest < SeatsioTestClient
     rescue Seatsio::Exception::SeatsioException => e
       assert_equal(400, e.message.code)
       wait_time = Time.now.to_i - start.to_i
-      assert_true(wait_time < 2)
+      assert_true(wait_time < 5)
     end
   end
 
@@ -37,7 +37,7 @@ class ExponentialBackoffTest < SeatsioTestClient
     rescue Seatsio::Exception::RateLimitExceededException => e
       assert_equal(429, e.message.code)
       wait_time = Time.now.to_i - start.to_i
-      assert_true(wait_time < 2)
+      assert_true(wait_time < 5)
     end
   end
 


### PR DESCRIPTION
Instead of throwing a generic SeatsioException (which is thrown in many cases, eg no focal point, event not found, etc), we now throw a BestAvailableObjectsNotFoundException (subclass of SeatsioException) to make it easier to handle this common specific case.